### PR TITLE
Add AGENTS guidelines for database

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Repository Guidelines
+
+This project uses the MySQL dump script `db.sql` to recreate the database `pacific_compressor`.
+When modifying database-related code or the dump itself, follow these instructions:
+
+1. Keep compatibility with MariaDB 10.4 syntax and defaults.
+2. Use `ALTER TABLE` statements instead of re-creating tables when updating the schema.
+3. Preserve existing default values, timestamps and foreign key constraints unless a change is required.
+4. Document any new tables or schema changes directly in `db.sql` using SQL comments.
+5. After editing the file, test the script by importing it with `mysql` or `phpMyAdmin` to ensure it runs cleanly.
+
+These guidelines apply to the whole repository.


### PR DESCRIPTION
## Summary
- add repository guidelines for working with `db.sql`

## Testing
- `mysql --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530e25bc248327a7e81e60212aa9e2