### PR TITLE
Fix JS files with reusable CRUD helper

### DIFF
--- a/vistas/js/cliente.js
+++ b/vistas/js/cliente.js
@@ -1,24 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'ClienteController.php';
-
-  const table = $('#tblCliente').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formCliente')[0].reset();
-    $('#modalCliente').modal('show');
+  initCrud({
+    controller: 'ClienteController.php',
+    tableId: 'tblCliente',
+    modalId: 'modalCliente',
+    formId: 'formCliente'
   });
 });

--- a/vistas/js/clienteContacto.js
+++ b/vistas/js/clienteContacto.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'ClienteContactoController.php';
-  const table = $('#tblClienteContacto').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formClienteContacto')[0].reset();
-    $('#modalClienteContacto').modal('show');
+  initCrud({
+    controller: 'ClienteContactoController.php',
+    tableId: 'tblClienteContacto',
+    modalId: 'modalClienteContacto',
+    formId: 'formClienteContacto'
   });
 });

--- a/vistas/js/clienteLocal.js
+++ b/vistas/js/clienteLocal.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'ClienteLocalController.php';
-  const table = $('#tblClienteLocal').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formClienteLocal')[0].reset();
-    $('#modalClienteLocal').modal('show');
+  initCrud({
+    controller: 'ClienteLocalController.php',
+    tableId: 'tblClienteLocal',
+    modalId: 'modalClienteLocal',
+    formId: 'formClienteLocal'
   });
 });

--- a/vistas/js/condicionPago.js
+++ b/vistas/js/condicionPago.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'CondicionPagoController.php';
-  const table = $('#tblCondicionPago').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formCondicionPago')[0].reset();
-    $('#modalCondicionPago').modal('show');
+  initCrud({
+    controller: 'CondicionPagoController.php',
+    tableId: 'tblCondicionPago',
+    modalId: 'modalCondicionPago',
+    formId: 'formCondicionPago'
   });
 });

--- a/vistas/js/contacto.js
+++ b/vistas/js/contacto.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'ContactoController.php';
-  const table = $('#tblContacto').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formContacto')[0].reset();
-    $('#modalContacto').modal('show');
+  initCrud({
+    controller: 'ContactoController.php',
+    tableId: 'tblContacto',
+    modalId: 'modalContacto',
+    formId: 'formContacto'
   });
 });

--- a/vistas/js/crud-helper.js
+++ b/vistas/js/crud-helper.js
@@ -1,0 +1,80 @@
+function initCrud(opts) {
+  const base = window.BASE_URL || '';
+  const ctrl = opts.controller;
+  const table = $('#' + opts.tableId).DataTable({
+    ajax: {
+      url: base + 'controlador/' + ctrl + '?op=listar',
+      type: 'GET',
+      dataSrc: 'data'
+    }
+  });
+
+  $('#btnNuevo').on('click', function () {
+    $('#' + opts.formId)[0].reset();
+    $('#' + opts.formId + ' [name="id"]').val('');
+    $('#' + opts.modalId + ' .modal-title').text('Nuevo');
+    $('#' + opts.modalId).modal('show');
+  });
+
+  $('#' + opts.tableId).on('click', '.btn-edit', function () {
+    const id = $(this).data('id');
+    $.post(base + 'controlador/' + ctrl + '?op=mostrar', { id }, function (r) {
+      if (r) {
+        Object.keys(r).forEach(k => {
+          $('#' + opts.formId + ' [name="' + k + '"]').val(r[k]);
+        });
+        $('#' + opts.modalId + ' .modal-title').text('Editar');
+        $('#' + opts.modalId).modal('show');
+      }
+    }, 'json');
+  });
+
+  $('#' + opts.tableId).on('click', '.btn-deactivate', function () {
+    const id = $(this).data('id');
+    Swal.fire({
+      title: '¿Desactivar registro?',
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonText: 'Sí, desactivar'
+    }).then(res => {
+      if (res.isConfirmed) {
+        $.post(base + 'controlador/' + ctrl + '?op=desactivar', { id }, function (resp) {
+          Swal.fire('', resp.msg, resp.status);
+          table.ajax.reload();
+        }, 'json');
+      }
+    });
+  });
+
+  $('#' + opts.tableId).on('click', '.btn-activate', function () {
+    const id = $(this).data('id');
+    Swal.fire({
+      title: '¿Activar registro?',
+      icon: 'question',
+      showCancelButton: true,
+      confirmButtonText: 'Sí, activar'
+    }).then(res => {
+      if (res.isConfirmed) {
+        $.post(base + 'controlador/' + ctrl + '?op=activar', { id }, function (resp) {
+          Swal.fire('', resp.msg, resp.status);
+          table.ajax.reload();
+        }, 'json');
+      }
+    });
+  });
+
+  $('#' + opts.formId).on('submit', function (e) {
+    e.preventDefault();
+    const idVal = $('#' + opts.formId + ' [name="id"]').val();
+    const op = idVal ? 'editar' : 'guardar';
+    $.post(base + 'controlador/' + ctrl + '?op=' + op, $(this).serialize(), function (resp) {
+      if (resp.status === 'success') {
+        $('#' + opts.modalId).modal('hide');
+        Swal.fire('Éxito', resp.msg, 'success');
+        table.ajax.reload();
+      } else {
+        Swal.fire('Error', resp.msg || 'Ocurrió un error', 'error');
+      }
+    }, 'json');
+  });
+}

--- a/vistas/js/equipo.js
+++ b/vistas/js/equipo.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'EquipoController.php';
-  const table = $('#tblEquipo').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formEquipo')[0].reset();
-    $('#modalEquipo').modal('show');
+  initCrud({
+    controller: 'EquipoController.php',
+    tableId: 'tblEquipo',
+    modalId: 'modalEquipo',
+    formId: 'formEquipo'
   });
 });

--- a/vistas/js/equipoModelo.js
+++ b/vistas/js/equipoModelo.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'EquipoModeloController.php';
-  const table = $('#tblEquipoModelo').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formEquipoModelo')[0].reset();
-    $('#modalEquipoModelo').modal('show');
+  initCrud({
+    controller: 'EquipoModeloController.php',
+    tableId: 'tblEquipoModelo',
+    modalId: 'modalEquipoModelo',
+    formId: 'formEquipoModelo'
   });
 });

--- a/vistas/js/equipoTipo.js
+++ b/vistas/js/equipoTipo.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'EquipoTipoController.php';
-  const table = $('#tblEquipoTipo').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formEquipoTipo')[0].reset();
-    $('#modalEquipoTipo').modal('show');
+  initCrud({
+    controller: 'EquipoTipoController.php',
+    tableId: 'tblEquipoTipo',
+    modalId: 'modalEquipoTipo',
+    formId: 'formEquipoTipo'
   });
 });

--- a/vistas/js/estadoCotizacion.js
+++ b/vistas/js/estadoCotizacion.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'EstadoCotizacionController.php';
-  const table = $('#tblEstadoCotizacion').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formEstadoCotizacion')[0].reset();
-    $('#modalEstadoCotizacion').modal('show');
+  initCrud({
+    controller: 'EstadoCotizacionController.php',
+    tableId: 'tblEstadoCotizacion',
+    modalId: 'modalEstadoCotizacion',
+    formId: 'formEstadoCotizacion'
   });
 });

--- a/vistas/js/estadoDocumento.js
+++ b/vistas/js/estadoDocumento.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'EstadoDocumentoController.php';
-  const table = $('#tblEstadoDocumento').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formEstadoDocumento')[0].reset();
-    $('#modalEstadoDocumento').modal('show');
+  initCrud({
+    controller: 'EstadoDocumentoController.php',
+    tableId: 'tblEstadoDocumento',
+    modalId: 'modalEstadoDocumento',
+    formId: 'formEstadoDocumento'
   });
 });

--- a/vistas/js/estadoEquipos.js
+++ b/vistas/js/estadoEquipos.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'EstadoEquiposController.php';
-  const table = $('#tblEstadoEquipos').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formEstadoEquipos')[0].reset();
-    $('#modalEstadoEquipos').modal('show');
+  initCrud({
+    controller: 'EstadoEquiposController.php',
+    tableId: 'tblEstadoEquipos',
+    modalId: 'modalEstadoEquipos',
+    formId: 'formEstadoEquipos'
   });
 });

--- a/vistas/js/estadoOrdenCompra.js
+++ b/vistas/js/estadoOrdenCompra.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'EstadoOrdenCompraController.php';
-  const table = $('#tblEstadoOrdenCompra').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formEstadoOrdenCompra')[0].reset();
-    $('#modalEstadoOrdenCompra').modal('show');
+  initCrud({
+    controller: 'EstadoOrdenCompraController.php',
+    tableId: 'tblEstadoOrdenCompra',
+    modalId: 'modalEstadoOrdenCompra',
+    formId: 'formEstadoOrdenCompra'
   });
 });

--- a/vistas/js/estadoOrdenTrabajo.js
+++ b/vistas/js/estadoOrdenTrabajo.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'EstadoOrdenTrabajoController.php';
-  const table = $('#tblEstadoOrdenTrabajo').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formEstadoOrdenTrabajo')[0].reset();
-    $('#modalEstadoOrdenTrabajo').modal('show');
+  initCrud({
+    controller: 'EstadoOrdenTrabajoController.php',
+    tableId: 'tblEstadoOrdenTrabajo',
+    modalId: 'modalEstadoOrdenTrabajo',
+    formId: 'formEstadoOrdenTrabajo'
   });
 });

--- a/vistas/js/formaPago.js
+++ b/vistas/js/formaPago.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'FormaPagoController.php';
-  const table = $('#tblFormaPago').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formFormaPago')[0].reset();
-    $('#modalFormaPago').modal('show');
+  initCrud({
+    controller: 'FormaPagoController.php',
+    tableId: 'tblFormaPago',
+    modalId: 'modalFormaPago',
+    formId: 'formFormaPago'
   });
 });

--- a/vistas/js/guiaRemModalidad.js
+++ b/vistas/js/guiaRemModalidad.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'GuiaRemModalidadController.php';
-  const table = $('#tblGuiaRemModalidad').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formGuiaRemModalidad')[0].reset();
-    $('#modalGuiaRemModalidad').modal('show');
+  initCrud({
+    controller: 'GuiaRemModalidadController.php',
+    tableId: 'tblGuiaRemModalidad',
+    modalId: 'modalGuiaRemModalidad',
+    formId: 'formGuiaRemModalidad'
   });
 });

--- a/vistas/js/guiaRemMotivo.js
+++ b/vistas/js/guiaRemMotivo.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'GuiaRemMotivoController.php';
-  const table = $('#tblGuiaRemMotivo').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formGuiaRemMotivo')[0].reset();
-    $('#modalGuiaRemMotivo').modal('show');
+  initCrud({
+    controller: 'GuiaRemMotivoController.php',
+    tableId: 'tblGuiaRemMotivo',
+    modalId: 'modalGuiaRemMotivo',
+    formId: 'formGuiaRemMotivo'
   });
 });

--- a/vistas/js/linea.js
+++ b/vistas/js/linea.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'LineaController.php';
-  const table = $('#tblLinea').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formLinea')[0].reset();
-    $('#modalLinea').modal('show');
+  initCrud({
+    controller: 'LineaController.php',
+    tableId: 'tblLinea',
+    modalId: 'modalLinea',
+    formId: 'formLinea'
   });
 });

--- a/vistas/js/marca.js
+++ b/vistas/js/marca.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'MarcaController.php';
-  const table = $('#tblMarca').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formMarca')[0].reset();
-    $('#modalMarca').modal('show');
+  initCrud({
+    controller: 'MarcaController.php',
+    tableId: 'tblMarca',
+    modalId: 'modalMarca',
+    formId: 'formMarca'
   });
 });

--- a/vistas/js/modulo.js
+++ b/vistas/js/modulo.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'ModuloController.php';
-  const table = $('#tblModulo').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formModulo')[0].reset();
-    $('#modalModulo').modal('show');
+  initCrud({
+    controller: 'ModuloController.php',
+    tableId: 'tblModulo',
+    modalId: 'modalModulo',
+    formId: 'formModulo'
   });
 });

--- a/vistas/js/moneda.js
+++ b/vistas/js/moneda.js
@@ -1,24 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'MonedaController.php';
-
-  const table = $('#tblMoneda').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formMoneda')[0].reset();
-    $('#modalMoneda').modal('show');
+  initCrud({
+    controller: 'MonedaController.php',
+    tableId: 'tblMoneda',
+    modalId: 'modalMoneda',
+    formId: 'formMoneda'
   });
 });

--- a/vistas/js/notificacion.js
+++ b/vistas/js/notificacion.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'NotificacionController.php';
-  const table = $('#tblNotificacion').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formNotificacion')[0].reset();
-    $('#modalNotificacion').modal('show');
+  initCrud({
+    controller: 'NotificacionController.php',
+    tableId: 'tblNotificacion',
+    modalId: 'modalNotificacion',
+    formId: 'formNotificacion'
   });
 });

--- a/vistas/js/permiso.js
+++ b/vistas/js/permiso.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'PermisoController.php';
-  const table = $('#tblPermiso').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formPermiso')[0].reset();
-    $('#modalPermiso').modal('show');
+  initCrud({
+    controller: 'PermisoController.php',
+    tableId: 'tblPermiso',
+    modalId: 'modalPermiso',
+    formId: 'formPermiso'
   });
 });

--- a/vistas/js/plantilla.js
+++ b/vistas/js/plantilla.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'PlantillaController.php';
-  const table = $('#tblPlantilla').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formPlantilla')[0].reset();
-    $('#modalPlantilla').modal('show');
+  initCrud({
+    controller: 'PlantillaController.php',
+    tableId: 'tblPlantilla',
+    modalId: 'modalPlantilla',
+    formId: 'formPlantilla'
   });
 });

--- a/vistas/js/plantillaHoras.js
+++ b/vistas/js/plantillaHoras.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'PlantillaHorasController.php';
-  const table = $('#tblPlantillaHoras').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formPlantillaHoras')[0].reset();
-    $('#modalPlantillaHoras').modal('show');
+  initCrud({
+    controller: 'PlantillaHorasController.php',
+    tableId: 'tblPlantillaHoras',
+    modalId: 'modalPlantillaHoras',
+    formId: 'formPlantillaHoras'
   });
 });

--- a/vistas/js/plantillaRepuesto.js
+++ b/vistas/js/plantillaRepuesto.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'PlantillaRepuestoController.php';
-  const table = $('#tblPlantillaRepuesto').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formPlantillaRepuesto')[0].reset();
-    $('#modalPlantillaRepuesto').modal('show');
+  initCrud({
+    controller: 'PlantillaRepuestoController.php',
+    tableId: 'tblPlantillaRepuesto',
+    modalId: 'modalPlantillaRepuesto',
+    formId: 'formPlantillaRepuesto'
   });
 });

--- a/vistas/js/plantillaRespuestoHora.js
+++ b/vistas/js/plantillaRespuestoHora.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'PlantillaRespuestoHoraController.php';
-  const table = $('#tblPlantillaRespuestoHora').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formPlantillaRespuestoHora')[0].reset();
-    $('#modalPlantillaRespuestoHora').modal('show');
+  initCrud({
+    controller: 'PlantillaRespuestoHoraController.php',
+    tableId: 'tblPlantillaRespuestoHora',
+    modalId: 'modalPlantillaRespuestoHora',
+    formId: 'formPlantillaRespuestoHora'
   });
 });

--- a/vistas/js/programacionServiciosTecnicos.js
+++ b/vistas/js/programacionServiciosTecnicos.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'ProgramacionServiciosTecnicosController.php';
-  const table = $('#tblProgramacionServiciosTecnicos').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formProgramacionServiciosTecnicos')[0].reset();
-    $('#modalProgramacionServiciosTecnicos').modal('show');
+  initCrud({
+    controller: 'ProgramacionServiciosTecnicosController.php',
+    tableId: 'tblProgramacionServiciosTecnicos',
+    modalId: 'modalProgramacionServiciosTecnicos',
+    formId: 'formProgramacionServiciosTecnicos'
   });
 });

--- a/vistas/js/proveedor.js
+++ b/vistas/js/proveedor.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'ProveedorController.php';
-  const table = $('#tblProveedor').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formProveedor')[0].reset();
-    $('#modalProveedor').modal('show');
+  initCrud({
+    controller: 'ProveedorController.php',
+    tableId: 'tblProveedor',
+    modalId: 'modalProveedor',
+    formId: 'formProveedor'
   });
 });

--- a/vistas/js/rol.js
+++ b/vistas/js/rol.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'RolController.php';
-  const table = $('#tblRol').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formRol')[0].reset();
-    $('#modalRol').modal('show');
+  initCrud({
+    controller: 'RolController.php',
+    tableId: 'tblRol',
+    modalId: 'modalRol',
+    formId: 'formRol'
   });
 });

--- a/vistas/js/rolPermiso.js
+++ b/vistas/js/rolPermiso.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'RolPermisoController.php';
-  const table = $('#tblRolPermiso').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formRolPermiso')[0].reset();
-    $('#modalRolPermiso').modal('show');
+  initCrud({
+    controller: 'RolPermisoController.php',
+    tableId: 'tblRolPermiso',
+    modalId: 'modalRolPermiso',
+    formId: 'formRolPermiso'
   });
 });

--- a/vistas/js/servicioTecnico.js
+++ b/vistas/js/servicioTecnico.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'ServicioTecnicoController.php';
-  const table = $('#tblServicioTecnico').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formServicioTecnico')[0].reset();
-    $('#modalServicioTecnico').modal('show');
+  initCrud({
+    controller: 'ServicioTecnicoController.php',
+    tableId: 'tblServicioTecnico',
+    modalId: 'modalServicioTecnico',
+    formId: 'formServicioTecnico'
   });
 });

--- a/vistas/js/sublinea.js
+++ b/vistas/js/sublinea.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'SublineaController.php';
-  const table = $('#tblSublinea').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formSublinea')[0].reset();
-    $('#modalSublinea').modal('show');
+  initCrud({
+    controller: 'SublineaController.php',
+    tableId: 'tblSublinea',
+    modalId: 'modalSublinea',
+    formId: 'formSublinea'
   });
 });

--- a/vistas/js/tipoArticulo.js
+++ b/vistas/js/tipoArticulo.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'TipoArticuloController.php';
-  const table = $('#tblTipoArticulo').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formTipoArticulo')[0].reset();
-    $('#modalTipoArticulo').modal('show');
+  initCrud({
+    controller: 'TipoArticuloController.php',
+    tableId: 'tblTipoArticulo',
+    modalId: 'modalTipoArticulo',
+    formId: 'formTipoArticulo'
   });
 });

--- a/vistas/js/tipoMovimientoAlmacen.js
+++ b/vistas/js/tipoMovimientoAlmacen.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'TipoMovimientoAlmacenController.php';
-  const table = $('#tblTipoMovimientoAlmacen').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formTipoMovimientoAlmacen')[0].reset();
-    $('#modalTipoMovimientoAlmacen').modal('show');
+  initCrud({
+    controller: 'TipoMovimientoAlmacenController.php',
+    tableId: 'tblTipoMovimientoAlmacen',
+    modalId: 'modalTipoMovimientoAlmacen',
+    formId: 'formTipoMovimientoAlmacen'
   });
 });

--- a/vistas/js/tipoRetencion.js
+++ b/vistas/js/tipoRetencion.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'TipoRetencionController.php';
-  const table = $('#tblTipoRetencion').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formTipoRetencion')[0].reset();
-    $('#modalTipoRetencion').modal('show');
+  initCrud({
+    controller: 'TipoRetencionController.php',
+    tableId: 'tblTipoRetencion',
+    modalId: 'modalTipoRetencion',
+    formId: 'formTipoRetencion'
   });
 });

--- a/vistas/js/tipoServicio.js
+++ b/vistas/js/tipoServicio.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'TipoServicioController.php';
-  const table = $('#tblTipoServicio').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formTipoServicio')[0].reset();
-    $('#modalTipoServicio').modal('show');
+  initCrud({
+    controller: 'TipoServicioController.php',
+    tableId: 'tblTipoServicio',
+    modalId: 'modalTipoServicio',
+    formId: 'formTipoServicio'
   });
 });

--- a/vistas/js/unidadMedida.js
+++ b/vistas/js/unidadMedida.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'UnidadMedidaController.php';
-  const table = $('#tblUnidadMedida').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formUnidadMedida')[0].reset();
-    $('#modalUnidadMedida').modal('show');
+  initCrud({
+    controller: 'UnidadMedidaController.php',
+    tableId: 'tblUnidadMedida',
+    modalId: 'modalUnidadMedida',
+    formId: 'formUnidadMedida'
   });
 });

--- a/vistas/js/usuario.js
+++ b/vistas/js/usuario.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'UsuarioController.php';
-  const table = $('#tblUsuario').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formUsuario')[0].reset();
-    $('#modalUsuario').modal('show');
+  initCrud({
+    controller: 'UsuarioController.php',
+    tableId: 'tblUsuario',
+    modalId: 'modalUsuario',
+    formId: 'formUsuario'
   });
 });

--- a/vistas/js/usuarioRol.js
+++ b/vistas/js/usuarioRol.js
@@ -1,23 +1,8 @@
 $(function () {
-  const base = window.BASE_URL;
-  const ctrl = 'UsuarioRolController.php';
-  const table = $('#tblUsuarioRol').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#formUsuarioRol')[0].reset();
-    $('#modalUsuarioRol').modal('show');
+  initCrud({
+    controller: 'UsuarioRolController.php',
+    tableId: 'tblUsuarioRol',
+    modalId: 'modalUsuarioRol',
+    formId: 'formUsuarioRol'
   });
 });

--- a/vistas/layout/footer.php
+++ b/vistas/layout/footer.php
@@ -82,6 +82,7 @@
 <script src="<?= APP_URL ?>app/template/plugins/styleswitcher/jQuery.style.switcher.js"></script>
 
 
+<script src="<?= APP_URL ?>vistas/js/crud-helper.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- add `crud-helper.js` with generic CRUD logic
- refactor most JS pages to use `initCrud`
- load the helper in `footer.php`

## Testing
- `php` not available, so syntax check was skipped

------
https://chatgpt.com/codex/tasks/task_e_685316b1586c83278e54efbbf1f18eaf