### PR TITLE
Optimize view JS usage

### DIFF
--- a/scripts/generate_views.php
+++ b/scripts/generate_views.php
@@ -60,39 +60,18 @@ foreach (glob("$controllerDir/*Controller.php") as $file) {
     </div>
     </div>
 <?php require 'layout/footer.php'; ?>
-  <script>window.BASE_URL = '<?= APP_URL ?>';</script>
-  <script src="js/{$lower}.js"></script>
+  <script>
+    window.BASE_URL = '<?= APP_URL ?>';
+    window.CRUD_CONFIG = {
+      controller: '{$base}Controller.php',
+      tableId: 'tbl{$base}',
+      modalId: 'modal{$base}',
+      formId: 'form{$base}'
+    };
+  </script>
+  <script src="js/init-crud.js"></script>
 PHP;
         file_put_contents($viewPath, $view);
     }
 
-    if (!file_exists($jsPath)) {
-        $lower = lcfirst($base);
-        $js = <<<JS
-$(function () {
-  const base = window.BASE_URL;
-  const ctrl = '{$base}Controller.php';
-  const table = $('#tbl{$base}').DataTable({
-    ajax: {
-      url: base + 'controlador/' + ctrl + '?op=listar',
-      type: 'GET',
-      dataSrc: function (json) {
-        const data = json.data || json.aaData || [];
-        if (data.length && $('#tblHead').children().length === 0) {
-          const headers = Object.keys(data[0]).map(k => `<th>\${k}</th>`).join('');
-          $('#tblHead').html('<tr>' + headers + '</tr>');
-        }
-        return data;
-      }
-    }
-  });
-
-  $('#btnNuevo').click(() => {
-    $('#form{$base}')[0].reset();
-    $('#modal{$base}').modal('show');
-  });
-});
-JS;
-        file_put_contents($jsPath, $js);
-    }
 }

--- a/vistas/categoriaCliente.php
+++ b/vistas/categoriaCliente.php
@@ -68,5 +68,11 @@
 <?php require "layout/footer.php"; ?>
 <script>
   window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'CategoriaClienteController.php',
+    tableId: 'tbllistadoCategories',
+    modalId: 'modalCategoria',
+    formId: 'formCategoria'
+  };
 </script>
-<script src="<?= APP_URL ?>vistas/js/categoriaCliente.js"></script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/categoriaProveedor.php
+++ b/vistas/categoriaProveedor.php
@@ -59,5 +59,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/categoriaProveedor.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'CategoriaProveedorController.php',
+    tableId: 'tblCategoriaProveedor',
+    modalId: 'modalCategoriaProveedor',
+    formId: 'formCategoriaProveedor'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/cliente.php
+++ b/vistas/cliente.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require 'layout/footer.php'; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/cliente.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'ClienteController.php',
+    tableId: 'tblCliente',
+    modalId: 'modalCliente',
+    formId: 'formCliente'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/clienteContacto.php
+++ b/vistas/clienteContacto.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/clienteContacto.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'ClienteContactoController.php',
+    tableId: 'tblClienteContacto',
+    modalId: 'modalClienteContacto',
+    formId: 'formClienteContacto'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/clienteLocal.php
+++ b/vistas/clienteLocal.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/clienteLocal.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'ClienteLocalController.php',
+    tableId: 'tblClienteLocal',
+    modalId: 'modalClienteLocal',
+    formId: 'formClienteLocal'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/condicionPago.php
+++ b/vistas/condicionPago.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/condicionPago.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'CondicionPagoController.php',
+    tableId: 'tblCondicionPago',
+    modalId: 'modalCondicionPago',
+    formId: 'formCondicionPago'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/contacto.php
+++ b/vistas/contacto.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/contacto.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'ContactoController.php',
+    tableId: 'tblContacto',
+    modalId: 'modalContacto',
+    formId: 'formContacto'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/equipo.php
+++ b/vistas/equipo.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/equipo.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'EquipoController.php',
+    tableId: 'tblEquipo',
+    modalId: 'modalEquipo',
+    formId: 'formEquipo'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/equipoModelo.php
+++ b/vistas/equipoModelo.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/equipoModelo.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'EquipoModeloController.php',
+    tableId: 'tblEquipoModelo',
+    modalId: 'modalEquipoModelo',
+    formId: 'formEquipoModelo'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/equipoTipo.php
+++ b/vistas/equipoTipo.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/equipoTipo.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'EquipoTipoController.php',
+    tableId: 'tblEquipoTipo',
+    modalId: 'modalEquipoTipo',
+    formId: 'formEquipoTipo'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/estadoCotizacion.php
+++ b/vistas/estadoCotizacion.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/estadoCotizacion.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'EstadoCotizacionController.php',
+    tableId: 'tblEstadoCotizacion',
+    modalId: 'modalEstadoCotizacion',
+    formId: 'formEstadoCotizacion'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/estadoDocumento.php
+++ b/vistas/estadoDocumento.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/estadoDocumento.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'EstadoDocumentoController.php',
+    tableId: 'tblEstadoDocumento',
+    modalId: 'modalEstadoDocumento',
+    formId: 'formEstadoDocumento'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/estadoEquipos.php
+++ b/vistas/estadoEquipos.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/estadoEquipos.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'EstadoEquiposController.php',
+    tableId: 'tblEstadoEquipos',
+    modalId: 'modalEstadoEquipos',
+    formId: 'formEstadoEquipos'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/estadoOrdenCompra.php
+++ b/vistas/estadoOrdenCompra.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/estadoOrdenCompra.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'EstadoOrdenCompraController.php',
+    tableId: 'tblEstadoOrdenCompra',
+    modalId: 'modalEstadoOrdenCompra',
+    formId: 'formEstadoOrdenCompra'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/estadoOrdenTrabajo.php
+++ b/vistas/estadoOrdenTrabajo.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/estadoOrdenTrabajo.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'EstadoOrdenTrabajoController.php',
+    tableId: 'tblEstadoOrdenTrabajo',
+    modalId: 'modalEstadoOrdenTrabajo',
+    formId: 'formEstadoOrdenTrabajo'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/formaPago.php
+++ b/vistas/formaPago.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/formaPago.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'FormaPagoController.php',
+    tableId: 'tblFormaPago',
+    modalId: 'modalFormaPago',
+    formId: 'formFormaPago'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/guiaRemModalidad.php
+++ b/vistas/guiaRemModalidad.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/guiaRemModalidad.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'GuiaRemModalidadController.php',
+    tableId: 'tblGuiaRemModalidad',
+    modalId: 'modalGuiaRemModalidad',
+    formId: 'formGuiaRemModalidad'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/guiaRemMotivo.php
+++ b/vistas/guiaRemMotivo.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/guiaRemMotivo.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'GuiaRemMotivoController.php',
+    tableId: 'tblGuiaRemMotivo',
+    modalId: 'modalGuiaRemMotivo',
+    formId: 'formGuiaRemMotivo'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/js/init-crud.js
+++ b/vistas/js/init-crud.js
@@ -1,0 +1,6 @@
+$(function () {
+  if (window.CRUD_CONFIG) {
+    initCrud(window.CRUD_CONFIG);
+  }
+});
+

--- a/vistas/linea.php
+++ b/vistas/linea.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/linea.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'LineaController.php',
+    tableId: 'tblLinea',
+    modalId: 'modalLinea',
+    formId: 'formLinea'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/marca.php
+++ b/vistas/marca.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/marca.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'MarcaController.php',
+    tableId: 'tblMarca',
+    modalId: 'modalMarca',
+    formId: 'formMarca'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/modulo.php
+++ b/vistas/modulo.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/modulo.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'ModuloController.php',
+    tableId: 'tblModulo',
+    modalId: 'modalModulo',
+    formId: 'formModulo'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/moneda.php
+++ b/vistas/moneda.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/moneda.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'MonedaController.php',
+    tableId: 'tblMoneda',
+    modalId: 'modalMoneda',
+    formId: 'formMoneda'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/notificacion.php
+++ b/vistas/notificacion.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/notificacion.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'NotificacionController.php',
+    tableId: 'tblNotificacion',
+    modalId: 'modalNotificacion',
+    formId: 'formNotificacion'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/permiso.php
+++ b/vistas/permiso.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/permiso.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'PermisoController.php',
+    tableId: 'tblPermiso',
+    modalId: 'modalPermiso',
+    formId: 'formPermiso'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/plantilla.php
+++ b/vistas/plantilla.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/plantilla.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'PlantillaController.php',
+    tableId: 'tblPlantilla',
+    modalId: 'modalPlantilla',
+    formId: 'formPlantilla'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/plantillaHoras.php
+++ b/vistas/plantillaHoras.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/plantillaHoras.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'PlantillaHorasController.php',
+    tableId: 'tblPlantillaHoras',
+    modalId: 'modalPlantillaHoras',
+    formId: 'formPlantillaHoras'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/plantillaRepuesto.php
+++ b/vistas/plantillaRepuesto.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/plantillaRepuesto.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'PlantillaRepuestoController.php',
+    tableId: 'tblPlantillaRepuesto',
+    modalId: 'modalPlantillaRepuesto',
+    formId: 'formPlantillaRepuesto'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/plantillaRespuestoHora.php
+++ b/vistas/plantillaRespuestoHora.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/plantillaRespuestoHora.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'PlantillaRespuestoHoraController.php',
+    tableId: 'tblPlantillaRespuestoHora',
+    modalId: 'modalPlantillaRespuestoHora',
+    formId: 'formPlantillaRespuestoHora'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/programacionServiciosTecnicos.php
+++ b/vistas/programacionServiciosTecnicos.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/programacionServiciosTecnicos.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'ProgramacionServiciosTecnicosController.php',
+    tableId: 'tblProgramacionServiciosTecnicos',
+    modalId: 'modalProgramacionServiciosTecnicos',
+    formId: 'formProgramacionServiciosTecnicos'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/proveedor.php
+++ b/vistas/proveedor.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/proveedor.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'ProveedorController.php',
+    tableId: 'tblProveedor',
+    modalId: 'modalProveedor',
+    formId: 'formProveedor'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/rol.php
+++ b/vistas/rol.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/rol.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'RolController.php',
+    tableId: 'tblRol',
+    modalId: 'modalRol',
+    formId: 'formRol'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/rolPermiso.php
+++ b/vistas/rolPermiso.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/rolPermiso.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'RolPermisoController.php',
+    tableId: 'tblRolPermiso',
+    modalId: 'modalRolPermiso',
+    formId: 'formRolPermiso'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/servicioTecnico.php
+++ b/vistas/servicioTecnico.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/servicioTecnico.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'ServicioTecnicoController.php',
+    tableId: 'tblServicioTecnico',
+    modalId: 'modalServicioTecnico',
+    formId: 'formServicioTecnico'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/sublinea.php
+++ b/vistas/sublinea.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/sublinea.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'SublineaController.php',
+    tableId: 'tblSublinea',
+    modalId: 'modalSublinea',
+    formId: 'formSublinea'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/tipoArticulo.php
+++ b/vistas/tipoArticulo.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/tipoArticulo.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'TipoArticuloController.php',
+    tableId: 'tblTipoArticulo',
+    modalId: 'modalTipoArticulo',
+    formId: 'formTipoArticulo'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/tipoMovimientoAlmacen.php
+++ b/vistas/tipoMovimientoAlmacen.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/tipoMovimientoAlmacen.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'TipoMovimientoAlmacenController.php',
+    tableId: 'tblTipoMovimientoAlmacen',
+    modalId: 'modalTipoMovimientoAlmacen',
+    formId: 'formTipoMovimientoAlmacen'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/tipoRetencion.php
+++ b/vistas/tipoRetencion.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/tipoRetencion.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'TipoRetencionController.php',
+    tableId: 'tblTipoRetencion',
+    modalId: 'modalTipoRetencion',
+    formId: 'formTipoRetencion'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/tipoServicio.php
+++ b/vistas/tipoServicio.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/tipoServicio.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'TipoServicioController.php',
+    tableId: 'tblTipoServicio',
+    modalId: 'modalTipoServicio',
+    formId: 'formTipoServicio'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/unidadMedida.php
+++ b/vistas/unidadMedida.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/unidadMedida.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'UnidadMedidaController.php',
+    tableId: 'tblUnidadMedida',
+    modalId: 'modalUnidadMedida',
+    formId: 'formUnidadMedida'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/usuario.php
+++ b/vistas/usuario.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/usuario.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'UsuarioController.php',
+    tableId: 'tblUsuario',
+    modalId: 'modalUsuario',
+    formId: 'formUsuario'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>

--- a/vistas/usuarioRol.php
+++ b/vistas/usuarioRol.php
@@ -44,5 +44,13 @@
     </div>
   </div>
 <?php require "layout/footer.php"; ?>
-<script>window.BASE_URL = '<?= APP_URL ?>';</script>
-<script src="<?= APP_URL ?>vistas/js/usuarioRol.js"></script>
+<script>
+  window.BASE_URL = '<?= APP_URL ?>';
+  window.CRUD_CONFIG = {
+    controller: 'UsuarioRolController.php',
+    tableId: 'tblUsuarioRol',
+    modalId: 'modalUsuarioRol',
+    formId: 'formUsuarioRol'
+  };
+</script>
+<script src="<?= APP_URL ?>vistas/js/init-crud.js"></script>


### PR DESCRIPTION
## Summary
- add `init-crud.js` to encapsulate repeated initialization logic
- update all view templates to use a single configurable script
- adjust `generate_views.php` so new views use the shared script

## Testing
- `php -l scripts/generate_views.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533697768483279a80692edb5899be